### PR TITLE
chore: disable use_dynamic_url as Chrome 130 is obviously not ready for it

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     "overrides": {
       "@webcomponents/custom-elements": "link:./empty",
       "rollup@2.78.1": "^2.79.2"
+    },
+    "patchedDependencies": {
+      "@crxjs/vite-plugin": "patches/@crxjs__vite-plugin.patch"
     }
   }
 }

--- a/patches/@crxjs__vite-plugin.patch
+++ b/patches/@crxjs__vite-plugin.patch
@@ -1,0 +1,21 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index c543f3e83ffb5210495ac735f9a906e59b9da491..d40cc9536ff6491702a7ae40b85a024f88a1adef 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1838,8 +1838,6 @@ const pluginWebAccessibleResources = () => {
+           matches: ["<all_urls>"],
+           // all resources are web accessible
+           resources: ["**/*", "*"],
+-          // change the extension origin on every reload
+-          use_dynamic_url: true
+         };
+         if (browser === "firefox") {
+           delete war.use_dynamic_url;
+@@ -1921,7 +1919,6 @@ const pluginWebAccessibleResources = () => {
+                   const resource = {
+                     matches: isDynamicScript ? [...dynamicScriptMatches] : matches,
+                     resources: [...assets, ...imports],
+-                    use_dynamic_url: isDynamicScript ? dynamicScriptDynamicUrl : true
+                   };
+                   if (isDynamicScript || !injectCss) {
+                     resource.resources.push(...css);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,11 @@ overrides:
   '@webcomponents/custom-elements': link:./empty
   rollup@2.78.1: ^2.79.2
 
+patchedDependencies:
+  '@crxjs/vite-plugin':
+    hash: 6y5bo5lqellg5dwpji7zksl3a4
+    path: patches/@crxjs__vite-plugin.patch
+
 importers:
 
   .:
@@ -17,7 +22,7 @@ importers:
         version: 1.9.3
       '@crxjs/vite-plugin':
         specifier: 2.0.0-beta.25
-        version: 2.0.0-beta.25
+        version: 2.0.0-beta.25(patch_hash=6y5bo5lqellg5dwpji7zksl3a4)
       '@hono/zod-openapi':
         specifier: ^0.16.4
         version: 0.16.4(hono@4.6.5)(zod@3.23.8)
@@ -2213,7 +2218,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.3':
     optional: true
 
-  '@crxjs/vite-plugin@2.0.0-beta.25':
+  '@crxjs/vite-plugin@2.0.0-beta.25(patch_hash=6y5bo5lqellg5dwpji7zksl3a4)':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@webcomponents/custom-elements': link:empty


### PR DESCRIPTION
Crxjs enable [use_dynamic_url](https://developer.chrome.com/docs/extensions/reference/manifest/web-accessible-resources) by default on development for no reason and it actually did nothing before Chrome 130.

Chrome 130 enable the ability of [use_dynamic_url](https://developer.chrome.com/docs/extensions/reference/manifest/web-accessible-resources) but things below are broken:

1. `import()` in a content script will fail due to [CSP reason](https://github.com/crxjs/chrome-extension-tools/issues/918)
2. `chrome.runtime.action.setPopup` will fail for a dynamic url.

Ref:

- https://developer.chrome.com/blog/extension-news-october-2024
- https://groups.google.com/a/chromium.org/g/chromium-extensions/c/Nr3QNKFv74c/m/PYLvA7dOAAAJ