### PR TITLE
chore: add csrf token to follow's post requests

### DIFF
--- a/scripts/follow-api.config.ts
+++ b/scripts/follow-api.config.ts
@@ -14,6 +14,10 @@ export const FollowApiConfig = {
      * @purpose Discover RSS links to follow later
      */
     "/discover",
+    /**
+     * @purpose all post/put APIs require CSRF token
+     */
+    "/auth/csrf",
   ] as (string | string[])[],
   generatedPath: "src/gen/follow.ts",
 };

--- a/src/backend/atoms/auth-state.ts
+++ b/src/backend/atoms/auth-state.ts
@@ -1,0 +1,15 @@
+import { inboxesAtom } from "@/backend/atoms/inboxes";
+import { isFollowError } from "@/lib/follow";
+import { asyncAtom } from "@/lib/jotai";
+
+export const authStateAtom = asyncAtom(async (get) => {
+  try {
+    await get(inboxesAtom);
+    return true;
+  } catch (e) {
+    if (isFollowError(e) && e.name === "AuthError") {
+      return false;
+    }
+    return true;
+  }
+});

--- a/src/backend/atoms/discover.ts
+++ b/src/backend/atoms/discover.ts
@@ -1,12 +1,15 @@
+import { csrfAtom } from "@/backend/atoms/follow-client";
 import { fixDiscoverUrl } from "@/lib/follow/fix-discover-url";
 import { asyncAtom } from "@/lib/jotai";
 import { follow, handleFollowResult } from "@/services/follow";
 import { atomFamily } from "jotai/utils";
 
 export const discoverAtom = atomFamily((url: string) => {
-  return asyncAtom(async (_, options) => {
+  return asyncAtom(async (get, options) => {
+    const csrf = await get(csrfAtom);
     const r = await follow.POST("/discover", {
       body: { keyword: fixDiscoverUrl(url), target: "feeds" },
+      headers: csrf.headers,
     });
     return handleFollowResult(r);
   });

--- a/src/backend/atoms/follow-client.ts
+++ b/src/backend/atoms/follow-client.ts
@@ -1,15 +1,16 @@
-import { inboxesAtom } from "@/backend/atoms/inboxes";
-import { isFollowError } from "@/lib/follow";
 import { asyncAtom } from "@/lib/jotai";
+import { follow } from "@/services/follow";
 
-export const authStateAtom = asyncAtom(async (get) => {
-  try {
-    await get(inboxesAtom);
-    return true;
-  } catch (e) {
-    if (isFollowError(e) && e.name === "AuthError") {
-      return false;
-    }
-    return true;
+export const csrfAtom = asyncAtom(async () => {
+  // @ts-ignore
+  const { data } = await follow.GET("/auth/csrf", {});
+  const token = (data as any)?.csrfToken;
+  const headers: any = {};
+  if (token) {
+    headers["X-CSRF-Token"] = token;
   }
+  return {
+    token,
+    headers,
+  };
 });

--- a/src/backend/atoms/index.ts
+++ b/src/backend/atoms/index.ts
@@ -1,4 +1,5 @@
 export * from "./settings";
 export * from "./chrome-storage";
 export * from "./inboxes";
+export * from "./auth-state";
 export * from "./follow-client";

--- a/src/backend/inbox.ts
+++ b/src/backend/inbox.ts
@@ -1,4 +1,4 @@
-import { inboxesAtom } from "@/backend/atoms";
+import { csrfAtom, inboxesAtom } from "@/backend/atoms";
 import { container } from "@/backend/container";
 import { readClient } from "@/content/read.backend";
 import { withNotification } from "@/lib/chrome/notification";
@@ -27,17 +27,20 @@ export async function sendToInbox({
       if (import.meta.env.DEV) {
         console.log("Send to inbox", payload);
       }
-      if (import.meta.env.DEV) {
+      if (false && import.meta.env.DEV) {
         await new Promise((resolve, reject) =>
           setTimeout(Math.random() > 0.5 ? resolve : reject, 1000, new Error("Test error"))
         );
       } else {
+        const csrf = await container.get(csrfAtom);
         await handleFollowResult(
           follow.POST("/inboxes/webhook", {
             credentials: "omit",
             headers: {
               "X-Follow-Secret": inbox?.secret,
               "X-Follow-Handle": inbox?.id,
+              // this endpoint is not supposed to be protected by CSRF, but it is.
+              ...csrf.headers,
             },
             body: payload,
           })


### PR DESCRIPTION
Follow is adding a draft csrf protecting implementation to its POST/PUT/etc requests.

This PR is to follow that change.